### PR TITLE
Use of defaults constants for not/topic, not/malicious-prompt

### DIFF
--- a/defaults/defaults.py
+++ b/defaults/defaults.py
@@ -2,6 +2,7 @@
 # Author: Pangea Cyber Corporation
 
 malicious_prompt_str = "malicious-prompt"
+not_malicious_prompt_str = "not-malicious-prompt"
 benign_str = "benign"
 
 
@@ -21,7 +22,10 @@ valid_topics = [
             "gibberish",
         ]
 valid_topics_str = ", ".join(valid_topics)
+topic_str = "topic"
+not_topic_str = "not-topic"
 topic_prefix = "topic:"
+not_topic_prefix = "not-topic:"
 
 # Need to be consistent with how the code handles detector names and topic names.
 # Want to allow --detectors to include both detector names and topic names, and to allow

--- a/manager/aiguard_manager.py
+++ b/manager/aiguard_manager.py
@@ -835,17 +835,17 @@ class AIGuardTests:
                             kind = label_field["kind"].strip().lower()
                             tag = label_field["tag"].strip().lower()
 
-                            if kind == "topic":
-                                labels.append(f"topic:{tag}")
-                            elif kind == "not-topic":
-                                labels.append(f"not-topic:{tag}")
-                            elif kind in ["notmaliciousprompt", "not-malicious-prompt"]:
+                            if kind == defaults.topic_str:
+                                labels.append(f"{defaults.topic_prefix}{tag}")
+                            elif kind == defaults.not_topic_str:
+                                labels.append(f"{defaults.not_topic_prefix}{tag}")
+                            elif kind in [defaults.not_malicious_prompt_str, defaults.not_malicious_prompt_str.replace("-","")]:
                                 # Negative expectation for the malicious-prompt detector.
                                 # Store BOTH the detector label (for per-detector stats)
                                 # *and* the negative-expectation marker so the efficacy tracker
                                 # knows this is a TN/FP scenario.
-                                labels.append("malicious-prompt")
-                                labels.append("not-malicious-prompt")
+                                labels.append(defaults.malicious_prompt_str)
+                                labels.append(defaults.not_malicious_prompt_str)
                             else:
                                 # For all other kinds, track the kind only; ignore the tagging metadata.
                                 if kind:


### PR DESCRIPTION
Updated more use of defaults constants for topic, not-topic, malicious-prompt, not-malicious-prompt